### PR TITLE
12 fix bug where if a pseudogene performs better than all real hits that the default pvalue threshold is set to zero

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intc"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "An implementation of the *-INC method to calculate an empirical FDR for non-targeting controls in CRISPR screens "
 license = "MIT"


### PR DESCRIPTION
- $\min{X} - \epsilon$ : when direction is `Some(Direction::Less)`
- $\max{X} - \epsilon$ : when direction is `Some(Direction::Greater)`
- $\min \left[ \set{\min{X} - \epsilon}, 0 \right]$ : when direction is `None`.

This makes it so the fdr threshold is just out of range in the directional tests, and will be just out of range in the classic pvalue test but will be guaranteed non-negative.